### PR TITLE
Update the hmcollector appVersion for HPE PDU telemetry

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.0] - 2021-11-30
+
+### Changed
+
+- hms-collector to version 2.15.0 for HPE PDU telemetry
+
 ## [2.15.0] - 2021-11-19
 
 ### Changed

--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,7 +5,7 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.15.0] - 2021-11-30
+## [2.15.1] - 2021-11-30
 
 ### Changed
 

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.0
+version: 2.15.1
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.14.0"
+appVersion: "2.15.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.15/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.14.0
+  appVersion: 2.15.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector
@@ -19,6 +19,7 @@ collectorIngressConfig:
 
   pollingEnabled: "false"
   pollingInterval: "30"
+  pduPollingInterval: "30"
 
   redfishSubscribeEnabled: "false"
   redfishStreamingEnabled: "false"
@@ -41,6 +42,7 @@ collectorPollConfig:
 
   pollingEnabled: "true"
   pollingInterval: "30"
+  pduPollingInterval: "30"
 
   redfishSubscribeEnabled: "true"
   redfishStreamingEnabled: "true"

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -10,6 +10,7 @@ chartVersionToCSMVersion:
 chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.15.0": "2.14.0"
+  "2.15.1": "2.15.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Update the hmcollector appVersion for HPE PDU telemetry support

## Issues and Related PRs

* Resolves [CASMHMS-5268](https://connect.us.cray.com/jira/browse/CASMHMS-5268)

## Testing

For testing see https://github.com/Cray-HPE/hms-hmcollector/pull/32

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable