### PR TITLE
Added pod anti-affinity.

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.3] - 2022-01-27
+
+### Changed
+
+- Added pod anti-affinity.
+
 ## [2.15.2] - 2021-12-15
 
 ### Changed

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.2
+version: 2.15.3
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:

--- a/charts/v2.15/cray-hms-hmcollector/templates/deployment.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/templates/deployment.yaml
@@ -7,6 +7,20 @@ metadata:
     app.kubernetes.io/name: cray-hms-hmcollector-ingress
 spec:
   replicas: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-hms-hmcollector
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/name: cray-hms-hmcollector-ingress

--- a/charts/v2.15/cray-hms-hmcollector/templates/deployment.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/templates/deployment.yaml
@@ -7,16 +7,6 @@ metadata:
     app.kubernetes.io/name: cray-hms-hmcollector-ingress
 spec:
   replicas: 3
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-      - topologyKey: kubernetes.io/hostname
-        labelSelector:
-          matchExpressions:
-            - key: app.kubernetes.io/name
-              operator: In
-              values:
-              - cray-hms-hmcollector
   strategy:
     rollingUpdate:
       maxUnavailable: 50%
@@ -102,6 +92,16 @@ spec:
               mountPath: /usr/local/cray-pki
           resources:
             {{- .Values.collectorIngressConfig.resources | toYaml | nindent 12 }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - cray-hms-hmcollector-ingress
       volumes:
         - name: hms-hmcollector-kafka-brokers
           configMap:

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -12,6 +12,7 @@ chartVersionToApplicationVersion:
   "2.15.0": "2.14.0"
   "2.15.1": "2.15.0"
   "2.15.2": "2.16.0"
+  "2.15.3": "2.16.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This service has been missing pod anti-affinity.  This mod adds it to the
service chart.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: © Copyright 2014-2020 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMINST-3922

### Testing

Tested on:

* wasp

Was a fresh Install tested? N   Not needed
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
Was a CT test run?          Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

Installed new chart and upgraded to it. Verified anti-affinity by looking at the
nodes the different pods run on before and after. Downgraded when finished.

### Risks and Mitigations

Low risk, no actual chart functional changes were made.

