### PR TITLE
Bump hms-hmcollector version to 2.17.0 to pickup fabric critical telemetry fix

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.4] - 2022-04-04
+
+### Changed
+
+- Bump hms-hmcollector version to 2.17.0 to pickup fabric critical telemetry fix 
+
 ## [2.15.3] - 2022-01-27
 
 ### Changed

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.3
+version: 2.15.4
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.16.0"
+appVersion: "2.17.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.15/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.16.0
+  appVersion: 2.17.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -13,6 +13,7 @@ chartVersionToApplicationVersion:
   "2.15.1": "2.15.0"
   "2.15.2": "2.16.0"
   "2.15.3": "2.16.0"
+  "2.15.4": "2.17.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Bump hms-hmcollector version to 2.17.0 to pickup fabric critical telemetry fix

## Issues and Related PRs

* Resolves [CASMHMS-5479](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5479)

## Testing

For testing see https://github.com/Cray-HPE/hms-hmcollector/pull/36

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable