### PR TITLE
CASMHMS-5426 Build hms-hmcollector using GitHub Actions

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.5] - 2022-04-29
+
+### Changed
+
+- CASMHMS-5414: Bump hms-hmcollector version to 2.18.0 for GitHub Actions transition.
+
 ## [2.15.4] - 2022-04-04
 
 ### Changed

--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,7 +5,7 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.15.5] - 2022-04-29
+## [2.15.5] - 2022-05-05
 
 ### Changed
 

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.4
+version: 2.15.5
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.17.0"
+appVersion: "2.18.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.15/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.17.0
+  appVersion: 2.18.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -14,6 +14,7 @@ chartVersionToApplicationVersion:
   "2.15.2": "2.16.0"
   "2.15.3": "2.16.0"
   "2.15.4": "2.17.0"
+  "2.15.5": "2.18.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update hms-hmcollector to build using GitHub Actions instead of Jenkins
- Pull images from algol60 Artifactory instead of arti.dev.cray.com
- Update Alpine base image version
- Stop building CT test RPMs for hms-hmcollector since the only test was for checking the health of the pod in k8s which will be covered by the PET team moving forward. This is part of our transition to Helm-based CT tests instead of RPMs.

### Issues and Related PRs

* Resolves CASMHMS-5426.
* Resolves CASMHMS-5414.

### Testing

This change was tested by verifying that the new hms-hmcollector version was built successfully using GitHub Actions and the resulting image was pushed to algol60 Artifactory. The newly built hms-hmcollector was also spun up locally in a docker-compose environment. No unit, integration, or CT tests to run for hms-hmcollector.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, only changing how hms-hmcollector is built and where images that it depends on are pulled from.