### PR TITLE
Change HSM v1 API References to v2 hms-hmcollector

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,13 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.7] - 2022-07-06
+
+### Changed
+
+- CASMHMS-5557: Bump hms-hmcollector version to 2.20.0 for changing HSM v1 API references to v2.
+- Made the number of replicas for ingress and poll pods configurable in values.yaml.
+
 ## [2.15.6] - 2022-05-20
 
 ### Changed

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.6
+version: 2.15.7
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.19.0"
+appVersion: "2.20.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.15/cray-hms-hmcollector/templates/deployment.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cray-hms-hmcollector-ingress
 spec:
-  replicas: 3
+  replicas: {{ .Values.collectorIngressConfig.replicas}}
   strategy:
     rollingUpdate:
       maxUnavailable: 50%
@@ -117,7 +117,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cray-hms-hmcollector-poll
 spec:
-  replicas: 1
+  replicas: {{ .Values.collectorPollConfig.replicas}}
   selector:
     matchLabels:
       app.kubernetes.io/name: cray-hms-hmcollector-poll

--- a/charts/v2.15/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.19.0
+  appVersion: 2.20.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector
@@ -15,6 +15,7 @@ podAnnotations: {}
 #   sidecar.istio.io/proxyMemoryLimit: 5Gi
 
 collectorIngressConfig:
+  replicas: 3
   logLevel: "INFO"
 
   pollingEnabled: "false"
@@ -38,6 +39,7 @@ collectorIngressConfig:
       memory: 256Mi
 
 collectorPollConfig:
+  replicas: 1
   logLevel: "INFO"
 
   pollingEnabled: "true"

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -16,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.15.4": "2.17.0"
   "2.15.5": "2.18.0"
   "2.15.6": "2.19.0"
+  "2.15.7": "2.20.0"
   
 
 # Test results for combinations of Chart, Application, and CSM versions.  


### PR DESCRIPTION
## Summary and Scope

Change HSM v1 API References to v2. This also, changes the helm chart so the number of ingress/poll replicas can be configured in values.yaml

## Issues and Related PRs

* Resolves [CASMHMS-5557](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5557)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable