### PR TITLE
CASMHMS-5776: Bump hms-hmcollector version to 2.22.0

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,16 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.8] - 2022-10-05
+
+### Changed
+
+- CASMHMS-5776: Bump hms-hmcollector version to 2.22.0 to switched over to use `ping` from the `iputils` package instead of from busybox to work around an issue
+  were busybox `ping` does not have permission when running as non-root user. 
+  
+  **Note** the 2.21.0 release of collector was made to remove a checked in certificate
+  into the git repository, and changes to the echo_server test program, neither of which are present in the container image built from the repo.
+
 ## [2.15.7] - 2022-07-06
 
 ### Changed

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.7
+version: 2.15.8
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.20.0"
+appVersion: "2.22.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.15/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.20.0
+  appVersion: 2.22.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

CASMHMS-5776: Bump hms-hmcollector version to 2.22.0 to switched over to use `ping` from the `iputils` package instead of from busybox to work around an issue
  were busybox `ping` does not have permission when running as non-root user. 
  
  **Note** the 2.21.0 release of collector was made to remove a checked in certificate
  into the git repository, and changes to the echo_server test program, neither of which are present in the container image built from the repo.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMHMS-5776
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

Tested on:

  * Tyr

For testing see: https://github.com/Cray-HPE/hms-hmcollector/pull/44

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable