### PR TITLE
CASMTRIAGE-4336:  Set hosts in VS to hmcollector_external_ip.

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.9] - 2022-10-07
+
+### Changed
+
+- CASMTRIAGE-4336: Set "hosts" in the virtual service to the HMN gateway IP.  This will prevent requests to other APIs that use api.hmnlb.<system-domain> from getting to the hmcollector service.
+
 ## [2.15.8] - 2022-10-05
 
 ### Changed

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.8
+version: 2.15.9
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:

--- a/charts/v2.15/cray-hms-hmcollector/templates/virtualservice.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/templates/virtualservice.yaml
@@ -8,7 +8,7 @@ spec:
   gateways:
   - {{ .Values.gateway }}
   hosts:
-  - '*'
+  - '{{ .Values.hmcollector_external_ip }}'
   http:
   - route:
     - destination:

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -17,6 +17,8 @@ chartVersionToApplicationVersion:
   "2.15.5": "2.18.0"
   "2.15.6": "2.19.0"
   "2.15.7": "2.20.0"
+  "2.15.8": "2.22.0"
+  "2.15.9": "2.22.0"
   
 
 # Test results for combinations of Chart, Application, and CSM versions.  


### PR DESCRIPTION
## Summary and Scope

Changing the "hosts" from a wildcard ("*") to the specific hostname that will be used to access the hmcollector service.  In this case, the hostname is actually the HMN gateway IP (e.g. 10.94.100.71).    This will prevent requests that are using api.hmnlb.<system-domain> from being routed to this service.

This change is backwards compatible.  It just makes the virtual service more restrictive in what will be routed to it.

## Issues and Related PRs

* Resolves CASMTRIAGE-4336

## Testing

Tested on:

  * `drax`

Test description:

Tested by manually changing the virtual service on drax.   

```
ncn-m001:~/johren # diff -cw orig fixed 
*** orig	2022-10-07 16:59:14.000998731 +0000
--- fixed	2022-10-07 16:59:22.061084307 +0000
***************
*** 17,23 ****
    gateways:
    - hmn-gateway
    hosts:
!   - "*"
    http:
    - route:
      - destination:
--- 17,23 ----
    gateways:
    - hmn-gateway
    hosts:
!   - 10.94.100.71
    http:
    - route:
      - destination:
```

Ran the ncn-gateway tests and verified that the other APIs now return 404s as expected.

Check the logs and verified that the POSTs to the hmcollector are still returning 200.

```
[2022-10-07T16:42:44.676Z] "POST /x3000c0s19b1 HTTP/1.1" 200 - via_upstream - "-" 510 0 7 5 "10.36.0.0" "-" "240f90d3-e3cb-421e-ab1c-bc6f1ec77f7c" "10.94.100.71" "10.36.0.44:80" outbound|80||cray-hms-hmcollector-ingress.services.svc.cluster.local 10.36.0.23:51202 10.36.0.23:80 10.36.0.0:18169 - -
```

## Risks and Mitigations

Low risk.   Mitigation is a manual virtual service workaround if an edge case is encountered.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable