### PR TITLE
Updated values.yaml to add support for ss health event streaming

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.10] - 2022-10-27
+
+### Changed
+
+- CASMPET-6092: Updated the hms collector config map by adding the cray-fabric-health-events kafka topic among the list of kafka topics to publish .  This update is required to support slingshot health event streaming.
+
 ## [2.15.9] - 2022-10-07
 
 ### Changed

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.9
+version: 2.15.10
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:

--- a/charts/v2.15/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/values.yaml
@@ -80,6 +80,7 @@ kafkaBrokers:
       - cray-fabric-perf-telemetry
       - cray-fabric-crit-telemetry
       - cray-dmtf-resource-event
+      - cray-fabric-health-events
   - BrokerAddress: cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092
     TopicsToPublish:
       - cray-dmtf-resource-event


### PR DESCRIPTION
## Summary and Scope

Added the cray-fabric-health-events kafka topic to the values.yaml list of kafka topics to publish. The lack of this addition was preventing health events from reaching kafka.

## Issues and Related PRs

https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6092

## Testing

values.yaml 
    kafka topic list
    version incremented

Tested on:
Shandy

Test description:
Dummy health events were pushed from switches to the hms-collector and were then seen within kafka.

<img width="770" alt="image" src="https://user-images.githubusercontent.com/49115175/196865552-09551152-23fe-4a42-9147-b2dca4db6626.png">
<img width="565" alt="image" src="https://user-images.githubusercontent.com/49115175/196865614-fa01b2cf-1dd7-4c99-ac19-23b23ef96074.png">
<img width="766" alt="image" src="https://user-images.githubusercontent.com/49115175/196865673-7944991c-29b8-4cf7-b156-2896119630aa.png">
