### PR TITLE
CASMHMS-5824: Pull in v2.23.0 version of the collector. 

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.11] - 2022-12-01
+
+### Changed
+
+- CASMHMS-5824: Pull in v2.23.0 version of the collector. Added a message key to kafka messages to ensure events are sent to the same Kafka partition. The message key is the BMC Xname concatenated with the Redfish Event Message ID. For example `x3000c0s11b4.EventLog.1.0.PowerStatusChange`. 
+
 ## [2.15.10] - 2022-10-27
 
 ### Changed

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.10
+version: 2.15.11
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.22.0"
+appVersion: "2.23.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.15/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.22.0
+  appVersion: 2.23.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -19,6 +19,8 @@ chartVersionToApplicationVersion:
   "2.15.7": "2.20.0"
   "2.15.8": "2.22.0"
   "2.15.9": "2.22.0"
+  "2.15.10": "2.22.0"
+  "2.15.11": "2.23.0"
   
 
 # Test results for combinations of Chart, Application, and CSM versions.  


### PR DESCRIPTION

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Pull in v2.23.0 version of the collector. Added a message key to kafka messages to ensure events are sent to the same Kafka partition. The message key is the BMC Xname concatenated with the Redfish Event Message ID. For example `x3000c0s11b4.EventLog.1.0.PowerStatusChange`. 


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards compatible

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMHMS-5824

## Testing

_List the environments in which these changes were tested._

Tested on:
  * Bradi
  * Mug

Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A no CT tests for collector
- Was upgrade tested? If not, why? yes
- Was downgrade tested? If not, why? yes

For testing see: https://github.com/Cray-HPE/hms-hmcollector/pull/45


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk, needed for the telemetry-metrics-filter to properly work.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable