### PR TITLE
Updated collector version to 2.25.0 and configmap with new kafka topic

### DIFF
--- a/changelog/v2.15.md
+++ b/changelog/v2.15.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.15.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.12] - 2023-01-19
+
+### Changed
+
+- CASMSMF-7120: Pull in v2.25.0 version of the collector. Added cray-fabric-health to the collector config map as this topic will replace cray-fabric-health-events and store both health event and health telemetry data.
+
 ## [2.15.11] - 2022-12-01
 
 ### Changed

--- a/charts/v2.15/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.15.11
+version: 2.15.12
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.23.0"
+appVersion: "2.25.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.15/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.15/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.23.0
+  appVersion: 2.25.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector
@@ -80,7 +80,7 @@ kafkaBrokers:
       - cray-fabric-perf-telemetry
       - cray-fabric-crit-telemetry
       - cray-dmtf-resource-event
-      - cray-fabric-health-events
+      - cray-fabric-health
   - BrokerAddress: cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092
     TopicsToPublish:
       - cray-dmtf-resource-event


### PR DESCRIPTION
Summary and Scope
Added the cray-fabric-health topic to the values.yaml list of kafka topics to publish. This topic replaces cray-fabric-health-events and will be storing both health telemetry and event data.

Issues and Related PRs
https://jira-pro.its.hpecorp.net:8443/browse/CASMSMF-7120

Please refer  https://github.com/Cray-HPE/hms-hmcollector/pull/48 for additional details.
