### PR TITLE
Changed to prune stale subscriptions by using app version 2.26.0

### DIFF
--- a/changelog/v2.16.md
+++ b/changelog/v2.16.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.16.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.1] - 2023-04-28
+
+### Changed
+
+- CASMHMS-5685: Prune event subscriptions with stale destinations and contexts
+
 ## [2.16.0] - 2023-01-31
 
 ### Changed

--- a/charts/v2.16/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.16.0
+version: 2.16.1
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.25.0"
+appVersion: "2.26.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.16/cray-hms-hmcollector/templates/deployment.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
             - name: REST_ENABLED
               value: "{{ .Values.collectorPollConfig.restEnabled }}"
 
-            - name: PRUNE_OLD_SUBSCRIPTIONS:
+            - name: PRUNE_OLD_SUBSCRIPTIONS
               value: "{{ .Values.collectorPollConfig.pruneOldSubscriptions }}"
 
             - name: HSM_REFRESH_INTERVAL

--- a/charts/v2.16/cray-hms-hmcollector/templates/deployment.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/templates/deployment.yaml
@@ -151,6 +151,9 @@ spec:
             - name: REST_ENABLED
               value: "{{ .Values.collectorPollConfig.restEnabled }}"
 
+            - name: PRUNE_OLD_SUBSCRIPTIONS:
+              value: "{{ .Values.collectorPollConfig.pruneOldSubscriptions }}"
+
             - name: HSM_REFRESH_INTERVAL
               value: "{{ .Values.collectorPollConfig.hsmRefreshInterval }}"
             - name: SM_URL

--- a/charts/v2.16/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.25.0
+  appVersion: 2.26.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/charts/v2.16/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/values.yaml
@@ -56,6 +56,8 @@ collectorPollConfig:
 
   vaultEnabled: "true"
 
+  pruneOldSubscriptions: "true"
+
   resources:
     limits:
       cpu: "4"

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -23,6 +23,7 @@ chartVersionToApplicationVersion:
   "2.15.11": "2.23.0"
   "2.15.12": "2.25.0"
   "2.16.0": "2.25.0"
+  "2.16.1": "2.26.0"
   
 
 # Test results for combinations of Chart, Application, and CSM versions.  


### PR DESCRIPTION

## Summary and Scope

Changed to prune stale subscriptions by using app version 2.26.0

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5685](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5685)

## Testing

Tested on:

  * docker compose env
  * mug

Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y


## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable