### PR TITLE
Fixup compatibility to match reality, add new telemetry

### DIFF
--- a/charts/v2.16/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.16.1
+version: 2.16.2
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.26.0"
+appVersion: "2.27.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.16/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.26.0
+  appVersion: 2.27.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector
@@ -80,6 +80,10 @@ kafkaBrokers:
       - cray-telemetry-pressure
       - cray-telemetry-humidity
       - cray-telemetry-liquidflow
+      - cray-telemetry-metric
+      - cray-telemetry-powerfactor
+      - cray-telemetry-frequency
+      - cray-telemetry-percent
       - cray-fabric-telemetry
       - cray-fabric-perf-telemetry
       - cray-fabric-crit-telemetry

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -2,7 +2,12 @@
 # CSM Version is not really following semver.
 chartVersionToCSMVersion:
   # Chart version: CSM version
-  ">=2.15.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  "~2.15.0": "~1.2.0" # Chart Version: 2.15.0 <= x.y.z < 2.16.0, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  "^2.16.0": "~1.3.0" # Chart Version: 2.16.0 == x.y.z, CSM Version: 1.3.0 <= x.y.z < 1.4.0
+  "^2.16.0": "~1.4.0" # Chart Version: 2.16.0 == x.y.z, CSM Version: 1.4.0 <= x.y.z < 1.5.0
+  "~2.16.0": "~1.5.0" # Chart Version: 2.16.0 <= x.y.z < 2.17.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
+  "~2.16.0": "~1.6.0" # Chart Version: 2.16.0 <= x.y.z < 2.17.0, CSM Version: 1.6.0 <= x.y.z < 1.7.0
+
 
 # The application version must be compliant to semantic versioning. 
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -23,7 +28,9 @@ chartVersionToApplicationVersion:
   "2.15.11": "2.23.0"
   "2.15.12": "2.25.0"
   "2.16.0": "2.25.0"
+  "2.16.0": "2.25.1"
   "2.16.1": "2.26.0"
+  "2.16.2": "2.27.0"
   
 
 # Test results for combinations of Chart, Application, and CSM versions.  


### PR DESCRIPTION
### Summary and Scope

New telemetry IDs are available from sCs and nCs on Olympus. 

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

### Issues and Related PRs

* Resolves CASMHMS-5831

### Testing

Tested on:

* `tyr`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Were continuous integration tests run? Y/N   Y
Was an Upgrade tested?                 Y/N   Y
Was a Downgrade tested?                Y/N  Y

Verified that the new telemetry IDs that were showing up in the hmcollector logs as unknown were no longer showing up as unknown.

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? (./runSnyk.sh) Y
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? SMF changes are needed to get the new telemetry into SMA Postgresql