### PR TITLE
Added support for Open BMC redfish

### DIFF
--- a/changelog/v2.16.md
+++ b/changelog/v2.16.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.16.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.4] - 2024-02-13
+
+### Changed
+
+- CASMHMS-6133: Added support for Open BMC redfish
+
 ## [2.16.3] - 2024-01-12
 
 ### Changed

--- a/charts/v2.16/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.16.3
+version: 2.16.4
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.28.0"
+appVersion: "2.30.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.16/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.28.0
+  appVersion: 2.30.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -32,6 +32,7 @@ chartVersionToApplicationVersion:
   "2.16.1": "2.26.0"
   "2.16.2": "2.27.0"
   "2.16.3": "2.28.0"
+  "2.16.4": "2.30.0"
   
 
 # Test results for combinations of Chart, Application, and CSM versions.  


### PR DESCRIPTION


## Summary and Scope

- Changed to use https when making subscriptions for OpenBMC
- Changed to check the length of the returned registryPrefixes
- Added a cache that holds the redfish implementation type for each endpoint
- Added polling of telemetry data for OpenBMC

CASMHMS-6127
CASMHMS-6133

## Issues and Related PRs

* Resolves [CASMHMS-6127](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6127)
* Resolves [CASMHMS-6133](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6133)

## Testing

Tested on:

  * tyr
  * Local development environment

Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y


## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable