### PR TITLE
Added support for foxconn paradise power events

### DIFF
--- a/changelog/v2.16.md
+++ b/changelog/v2.16.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.16.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.7] - 2024-05-30
+
+### Added
+
+- CASMHMS-6208: Support Foxconn Paradise Open BMC power events
+
 ## [2.16.6] - 2024-05-07
 
 ### Changed

--- a/charts/v2.16/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.16.6
+version: 2.16.7
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.32.0"
+appVersion: "2.33.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.16/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.32.0
+  appVersion: 2.33.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -35,6 +35,7 @@ chartVersionToApplicationVersion:
   "2.16.4": "2.30.0"
   "2.16.5": "2.31.0"
   "2.16.6": "2.32.0"
+  "2.16.7": "2.33.0"
   
 
 # Test results for combinations of Chart, Application, and CSM versions.  


### PR DESCRIPTION
## Summary and Scope

Paradise (OpenBMC) events are json where the Events field is a single object. The normal content for the Events field is an array of events.

This changes hmcollector to parse both options Events as an array and Events as an object. It then convers the Events as an object case to the array format before sending it to hsm via kafka.

CASMHMS-6208

## Issues and Related PRs

* Resolves [CASMHMS-6208](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6208)

## Testing

Tested on:

  * tyr
  * Local development environment

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable