### PR TITLE
CASMHMS-6295: Resolved some scaling/resource issues

### DIFF
--- a/.github/workflows/charts_lint_test_scan.yaml
+++ b/.github/workflows/charts_lint_test_scan.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   lint-test-scan:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/charts_lint_test_scan.yaml@v2
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/charts_lint_test_scan.yaml@v4
     with:
       lint-charts: ${{ github.event_name == 'pull_request' }}
       test-charts: false

--- a/changelog/v2.16.md
+++ b/changelog/v2.16.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.16.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.8] - 2024-12-06
+
+### Fixed
+
+- Resolved some scaling/resource issues
+
 ## [2.16.7] - 2024-05-30
 
 ### Added

--- a/changelog/v2.16.md
+++ b/changelog/v2.16.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Resolved some scaling/resource issues
+- Updated version of Go to 1.23
 
 ## [2.16.7] - 2024-05-30
 

--- a/charts/v2.16/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.16.7
+version: 2.16.8
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.33.0"
+appVersion: "2.34.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.16/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.33.0
+  appVersion: 2.34.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -36,7 +36,7 @@ chartVersionToApplicationVersion:
   "2.16.5": "2.31.0"
   "2.16.6": "2.32.0"
   "2.16.7": "2.33.0"
-  
+  "2.16.8": "2.34.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Resolved some scaling/resource issues relating to:

- Draining/closing HTTP response/request bodies
- Explicitly calling cancel on any created contexts
- Explicitly closing any created communication channels

Additionally, for consistency with similar changes to other HSM services, updated to use Go 1.23.

Adopted app version 2.34.0 for both CSM 1.5.3 and CSM 1.6.1 (helm chart 2.16.8)

### Issues and Related PRs

* Resolves [CASMHMS-6299](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6299)

## Testing

Test description:

All integration and unit tests pass in the build pipeline.

Deployed on rocket and:

- Confirmed correct functionality with no regressions
- Enabled logging in ingress deployment for x9000c1s2b0 to verify telemetry still streaming for it to kafka
- Power cycled x9000c1s2b0n0 and confirmed power on/off events still received and logged
- Verified in all hmcollector logs no sign of errors during all testing
- Unfortunately, no system CT tests exist for hmcollector

Testing Check List:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable