### PR TITLE
CASMHMS-6324: Added support for ppprof builds

### DIFF
--- a/changelog/v2.16.md
+++ b/changelog/v2.16.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.16.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.9] - 2025-01-08
+
+### Added
+
+- Added support for ppprof builds
+
 ## [2.16.8] - 2024-12-06
 
 ### Fixed

--- a/charts/v2.16/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/Chart.yaml
@@ -8,9 +8,9 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.35.0"
+appVersion: "2.35.0" # update pprof image version below as well
 annotations:
-  artifacthub.io/license: "MIT"
   artifacthub.io/images: |-
     - name: cray-hms-hmcollector-pprof
       image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.35.0
+  artifacthub.io/license: "MIT"

--- a/charts/v2.16/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.16.8
+version: 2.16.9
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.34.0"
+appVersion: "2.35.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.16/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.35.0" # update pprof image version below as well
+appVersion: "2.35.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hms-hmcollector-pprof

--- a/charts/v2.16/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/Chart.yaml
@@ -11,3 +11,6 @@ maintainers:
 appVersion: "2.35.0"
 annotations:
   artifacthub.io/license: "MIT"
+  artifacthub.io/images: |-
+    - name: cray-hms-hmcollector-pprof
+      image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.35.0

--- a/charts/v2.16/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.16/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.34.0
+  appVersion: 2.35.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -37,6 +37,7 @@ chartVersionToApplicationVersion:
   "2.16.6": "2.32.0"
   "2.16.7": "2.33.0"
   "2.16.8": "2.34.0"
+  "2.16.9": "2.35.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Added support for building a pprof enabled image.  Profiling adds runtime overhead so the pprof enabled image is not used by default.  It is meant to be a debug tool.  In order to use the enabled pprof image, edit the deployment and append "-pprof" to the image name.  For unstable developer builds, be sure to change the built timestamp as well.

Adopted app version 2.35.0 for CSM 1.6.1 (helm chart 2.16.9)

## Issues and Related PRs

* Resolves [CASMHMS-6324](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6324)

## Testing

Tested on:

  * `mug`

Test description:

- Deployed service with pprof enabled - confirmed pprof functionality
- Deployed services with pprof disabled - confirmed pprof support not built into binary
- Functional tests (if they exist) was successfully ran with and without pprof enabled

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable