### PR TITLE
CASMHMS-5678: Update image and module dependencies

### DIFF
--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -1,0 +1,12 @@
+# Changelog for v2.17
+
+All notable changes to this project for v2.17.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.17.0] - 2025-01-29
+
+### Security
+
+- Update image and module dependencies

--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,8 +5,9 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.17.0] - 2025-01-29
+## [2.17.0] - 2025-01-28
 
 ### Security
 
 - Update image and module dependencies
+- Various code changes to accomodate module updates

--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,7 +5,7 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.17.0] - 2025-01-28
+## [2.17.0] - 2025-01-27
 
 ### Security
 

--- a/charts/v2.17/cray-hms-hmcollector/.gitignore
+++ b/charts/v2.17/cray-hms-hmcollector/.gitignore
@@ -1,0 +1,5 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*
+helm/*
+# Ignore also any built charts
+*.tgz

--- a/charts/v2.17/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: "cray-hms-hmcollector"
+version: 2.17.0
+description: "Kubernetes resources for cray-hms-hmcollector"
+home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-hmcollector"
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "2.36.0"  # update pprof image version below as well
+annotations:
+  artifacthub.io/images: |-
+    - name: cray-hms-hmcollector-pprof
+      image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.36.0
+  artifacthub.io/license: "MIT"

--- a/charts/v2.17/cray-hms-hmcollector/files/kafka_brokers.json
+++ b/charts/v2.17/cray-hms-hmcollector/files/kafka_brokers.json
@@ -1,0 +1,14 @@
+[
+{{- $kafkaBrokers := .Values.kafkaBrokers -}}
+{{- range $i, $kafkaBroker := $kafkaBrokers }}
+  {
+    "BrokerAddress": "{{ .BrokerAddress }}",
+    "TopicsToPublish": {
+      {{- $topicsToPublish := .TopicsToPublish -}}
+      {{- range $ii, $element := $topicsToPublish }}
+      "{{ . }}": null{{ if not (eq $ii (sub (len $topicsToPublish) 1)) }},{{ end }}
+      {{- end }}
+    }
+  }{{ if not (eq $i (sub (len $kafkaBrokers) 1)) }},{{ end }}
+{{- end }}
+]

--- a/charts/v2.17/cray-hms-hmcollector/templates/configmaps.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/templates/configmaps.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hms-hmcollector-kafka-brokers
+  namespace: services
+data:
+  kafka_brokers.json: |-
+{{ tpl (.Files.Get "files/kafka_brokers.json") . | indent 4 }}
+

--- a/charts/v2.17/cray-hms-hmcollector/templates/deployment.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/templates/deployment.yaml
@@ -1,0 +1,215 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cray-hms-hmcollector-ingress
+  labels:
+    app.kubernetes.io/name: cray-hms-hmcollector-ingress
+spec:
+  replicas: {{ .Values.collectorIngressConfig.replicas}}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cray-hms-hmcollector-ingress
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cray-hms-hmcollector-ingress
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundPorts: "8082,9092,2181"
+        {{- if .Values.podAnnotations }}
+        {{- .Values.podAnnotations | toYaml | nindent 8 -}}
+        {{- end }}
+    spec:
+      containers:
+        - name: cray-hms-hmcollector-ingress
+          image: {{ .Values.image.repository }}:{{ default .Values.global.appVersion .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: LOG_LEVEL
+              value: "{{ .Values.collectorIngressConfig.logLevel}}"
+
+            - name: POLLING_ENABLED
+              value: "{{ .Values.collectorIngressConfig.pollingEnabled }}"
+            - name: POLLING_INTERVAL
+              value: "{{ .Values.collectorIngressConfig.pollingInterval }}"
+
+            - name: RF_SUBSCRIBE_ENABLED
+              value: "{{ .Values.collectorIngressConfig.redfishSubscribeEnabled }}"
+            - name: RF_STREAMING_ENABLED
+              value: "{{ .Values.collectorIngressConfig.redfishStreamingEnabled }}"
+            - name: REST_ENABLED
+              value: "{{ .Values.collectorIngressConfig.restEnabled }}"
+
+            - name: HSM_REFRESH_INTERVAL
+              value: "{{ .Values.collectorIngressConfig.hsmRefreshInterval }}"
+            - name: SM_URL
+              value: "http://cray-smd"
+
+            - name: REST_URL
+              value: "http://{{ .Values.hmcollector_external_ip }}"
+
+            - name: VAULT_ENABLED
+              value: "{{ .Values.collectorIngressConfig.vaultEnabled }}"
+            - name: VAULT_ADDR
+              value: "http://cray-vault.vault:8200"
+            - name: VAULT_SKIP_VERIFY
+              value: "true"
+            - name: VAULT_KEYPATH
+              value: "secret/hms-creds"
+            - name: HMCOLLECTOR_CA_URI
+              value: "{{ .Values.hms_ca_uri }}"
+            - name: LOG_MODES
+              value: ""
+            - name: LOG_XNAMES
+              value: ""
+#            - name: HMCOLLECTOR_LOG_INSECURE_FAILOVER
+#              value: true
+          ports:
+            - containerPort: 80
+              name: hmc-insecure
+            - containerPort: 443
+              name: hmc-secure
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: hmc-insecure
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: hmc-insecure
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: hms-hmcollector-kafka-brokers
+              mountPath: /configs/kafka_brokers.json
+              readOnly: true
+              subPath: kafka_brokers.json
+            - name: cray-pki-cacert-vol
+              mountPath: /usr/local/cray-pki
+          resources:
+            {{- .Values.collectorIngressConfig.resources | toYaml | nindent 12 }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - cray-hms-hmcollector-ingress
+      volumes:
+        - name: hms-hmcollector-kafka-brokers
+          configMap:
+            name: hms-hmcollector-kafka-brokers
+        - name: cray-pki-cacert-vol
+          configMap:
+            name: cray-configmap-ca-public-key
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cray-hms-hmcollector-poll
+  labels:
+    app.kubernetes.io/name: cray-hms-hmcollector-poll
+spec:
+  replicas: {{ .Values.collectorPollConfig.replicas}}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cray-hms-hmcollector-poll
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cray-hms-hmcollector-poll
+      annotations:
+        traffic.sidecar.istio.io/excludeOutboundPorts: "8082,9092,2181"
+        {{- if .Values.podAnnotations }}
+        {{- .Values.podAnnotations | toYaml | nindent 8 -}}
+        {{- end }}
+    spec:
+      containers:
+        - name: cray-hms-hmcollector
+          image: {{ .Values.image.repository }}:{{ default .Values.global.appVersion .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: LOG_LEVEL
+              value: "{{ .Values.collectorPollConfig.logLevel}}"
+
+            - name: POLLING_ENABLED
+              value: "{{ .Values.collectorPollConfig.pollingEnabled }}"
+            - name: POLLING_INTERVAL
+              value: "{{ .Values.collectorPollConfig.pollingInterval }}"
+
+            - name: RF_SUBSCRIBE_ENABLED
+              value: "{{ .Values.collectorPollConfig.redfishSubscribeEnabled }}"
+            - name: RF_STREAMING_ENABLED
+              value: "{{ .Values.collectorPollConfig.redfishStreamingEnabled }}"
+            - name: REST_ENABLED
+              value: "{{ .Values.collectorPollConfig.restEnabled }}"
+
+            - name: PRUNE_OLD_SUBSCRIPTIONS
+              value: "{{ .Values.collectorPollConfig.pruneOldSubscriptions }}"
+
+            - name: HSM_REFRESH_INTERVAL
+              value: "{{ .Values.collectorPollConfig.hsmRefreshInterval }}"
+            - name: SM_URL
+              value: "http://cray-smd"
+
+            - name: REST_URL
+              value: "http://{{ .Values.hmcollector_external_ip }}"
+
+            - name: VAULT_ENABLED
+              value: "{{ .Values.collectorPollConfig.vaultEnabled }}"
+            - name: VAULT_ADDR
+              value: "http://cray-vault.vault:8200"
+            - name: VAULT_SKIP_VERIFY
+              value: "true"
+            - name: VAULT_KEYPATH
+              value: "secret/hms-creds"
+            - name: HMCOLLECTOR_CA_URI
+              value: "{{ .Values.hms_ca_uri }}"
+#            - name: HMCOLLECTOR_LOG_INSECURE_FAILOVER
+#              value: true
+          ports:
+            - containerPort: 80
+              name: hmc-insecure
+            - containerPort: 443
+              name: hmc-secure
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: hmc-insecure
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: hmc-insecure
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: hms-hmcollector-kafka-brokers
+              mountPath: /configs/kafka_brokers.json
+              readOnly: true
+              subPath: kafka_brokers.json
+            - name: cray-pki-cacert-vol
+              mountPath: /usr/local/cray-pki
+          resources:
+            {{- .Values.collectorPollConfig.resources | toYaml | nindent 12 }}
+      volumes:
+        - name: hms-hmcollector-kafka-brokers
+          configMap:
+            name: hms-hmcollector-kafka-brokers
+        - name: cray-pki-cacert-vol
+          configMap:
+            name: cray-configmap-ca-public-key

--- a/charts/v2.17/cray-hms-hmcollector/templates/service.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cray-hms-hmcollector-ingress
+  labels:
+    app.kubernetes.io/name: cray-hms-hmcollector-ingress
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  annotations:
+    metallb.universe.tf/address-pool: hardware-management
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ .Values.hmcollector_external_ip }}
+  {{- end }}
+  ports:
+    - port: 80
+      targetPort: hmc-insecure
+      name: hmc-proxy-insecure
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: cray-hms-hmcollector-ingress

--- a/charts/v2.17/cray-hms-hmcollector/templates/virtualservice.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/templates/virtualservice.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/instance: cray-hms-hmcollector-ingress
+  name: cray-hms-hmcollector-ingress
+spec:
+  gateways:
+  - {{ .Values.gateway }}
+  hosts:
+  - '{{ .Values.hmcollector_external_ip }}'
+  {{- if .Values.hmcollector_external_hostname }}
+  - '{{ .Values.hmcollector_external_hostname }}'
+  {{ end }}
+  http:
+  - route:
+    - destination:
+        host: cray-hms-hmcollector-ingress
+        port:
+          number: 80

--- a/charts/v2.17/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/values.yaml
@@ -1,0 +1,94 @@
+---
+global:
+  appVersion: 2.36.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector
+  pullPolicy: IfNotPresent
+
+# These two fields will get overwritten by customizations.yaml.
+# See https://github.com/Cray-HPE/csm/blob/main/vendor/stash.us.cray.com/scm/shasta-cfg/stable/customizations.yaml for more details.
+hmcollector_external_ip: "10.94.100.71"
+hmcollector_external_hostname: ""  # This field is system specific, and in the form of mcollector.hmnlb.<system-name>.<site-domain>
+
+podAnnotations: {}
+# For example, override the default Istio sidecar proxy memory limit:
+# podAnnotations:
+#   sidecar.istio.io/proxyMemoryLimit: 5Gi
+
+collectorIngressConfig:
+  replicas: 3
+  logLevel: "INFO"
+
+  pollingEnabled: "false"
+  pollingInterval: "30"
+  pduPollingInterval: "30"
+
+  redfishSubscribeEnabled: "false"
+  redfishStreamingEnabled: "false"
+  restEnabled: "true"
+
+  hsmRefreshInterval: "30"
+
+  vaultEnabled: "false"
+
+  resources:
+    limits:
+      cpu: "4"
+      memory: 5Gi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+
+collectorPollConfig:
+  replicas: 1
+  logLevel: "INFO"
+
+  pollingEnabled: "true"
+  pollingInterval: "30"
+  pduPollingInterval: "30"
+
+  redfishSubscribeEnabled: "true"
+  redfishStreamingEnabled: "true"
+  restEnabled: "false"
+
+  hsmRefreshInterval: "30"
+
+  vaultEnabled: "true"
+
+  pruneOldSubscriptions: "true"
+
+  resources:
+    limits:
+      cpu: "4"
+      memory: 5Gi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+
+gateway: hmn-gateway
+service:
+  type: ClusterIP
+kafkaBrokers:
+  - BrokerAddress: cluster-kafka-bootstrap.sma.svc.cluster.local:9092
+    TopicsToPublish:
+      - cray-telemetry-temperature
+      - cray-telemetry-voltage
+      - cray-telemetry-power
+      - cray-telemetry-energy
+      - cray-telemetry-fan
+      - cray-telemetry-pressure
+      - cray-telemetry-humidity
+      - cray-telemetry-liquidflow
+      - cray-telemetry-metric
+      - cray-telemetry-powerfactor
+      - cray-telemetry-frequency
+      - cray-telemetry-percent
+      - cray-fabric-telemetry
+      - cray-fabric-perf-telemetry
+      - cray-fabric-crit-telemetry
+      - cray-dmtf-resource-event
+      - cray-fabric-health
+  - BrokerAddress: cray-shared-kafka-kafka-bootstrap.services.svc.cluster.local:9092
+    TopicsToPublish:
+      - cray-dmtf-resource-event

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -7,7 +7,7 @@ chartVersionToCSMVersion:
   "^2.16.0": "~1.4.0" # Chart Version: 2.16.0 == x.y.z, CSM Version: 1.4.0 <= x.y.z < 1.5.0
   "~2.16.0": "~1.5.0" # Chart Version: 2.16.0 <= x.y.z < 2.17.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
   "~2.16.0": "~1.6.0" # Chart Version: 2.16.0 <= x.y.z < 2.17.0, CSM Version: 1.6.0 <= x.y.z < 1.7.0
-
+  "~2.17.0": "~1.7.0" # Chart Version: 2.17.0 <= x.y.z,          CSM Version: 1.7.0 <= x.y.z
 
 # The application version must be compliant to semantic versioning. 
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -38,6 +38,7 @@ chartVersionToApplicationVersion:
   "2.16.7": "2.33.0"
   "2.16.8": "2.34.0"
   "2.16.9": "2.35.0"
+  "2.17.0": "2.36.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated image and module dependencies for security updates.

Added musl tag in builds which is required for newer versions of kafka

Updating the hms-base module included code changes required to reference code that was moved from hms-base to the hms-xname module.

Updates to hms-certs, hms-compcredentials, and hms-securestorage were not included.  A new Jira will be created to handle them seperately.  This is because updating these modules will require functional changes surrounding vault use due to the changes associated with CASMHMS-5445.

Adopted app version 2.17.0 for CSM 1.7.0 (helm chart 2.36.0)

### Issues and Related PRs

* Resolves [CASMHMS-5678](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5678)

### Testing

Updated surtur with new version.  Ensured no issues in log files.  Power cycled node to ensure state changes rippled back to SMD.

Tested on:

* `surtur`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

### High Level Diff of Changes
```
> diff -r charts/v2.16/ charts/v2.17/
diff -r charts/v2.16/cray-hms-hmcollector/Chart.yaml charts/v2.17/cray-hms-hmcollector/Chart.yaml
3c3
< version: 2.16.9
---
> version: 2.17.0
11c11
< appVersion: "2.35.0"  # update pprof image version below as well
---
> appVersion: "2.36.0"  # update pprof image version below as well
15c15
<       image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.35.0
---
>       image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.36.0
diff -r charts/v2.16/cray-hms-hmcollector/values.yaml charts/v2.17/cray-hms-hmcollector/values.yaml
3c3
<   appVersion: 2.35.0
---
>   appVersion: 2.36.0
```