### PR TITLE
CASMHMS-6409: Update module dependencies related to hms-certs

### DIFF
--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.1] - 2025-03-11
+
+### Security
+
+- Update module dependencies related to hms-certs
+
 ## [2.17.0] - 2025-01-27
 
 ### Security

--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,7 +5,7 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.17.1] - 2025-03-10
+## [2.17.1] - 2025-03-11
 
 ### Security
 

--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,11 +5,12 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.17.1] - 2025-03-11
+## [2.17.1] - 2025-03-10
 
 ### Security
 
 - Update module dependencies related to hms-certs
+- Updated vault override variables due to hms-certs update
 
 ## [2.17.0] - 2025-01-27
 

--- a/charts/v2.17/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.17.0
+version: 2.17.1
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,9 +8,9 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.36.0"  # update pprof image version below as well
+appVersion: "2.37.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hms-hmcollector-pprof
-      image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.36.0
+      image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.37.0
   artifacthub.io/license: "MIT"

--- a/charts/v2.17/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.36.0
+  appVersion: 2.37.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -39,6 +39,7 @@ chartVersionToApplicationVersion:
   "2.16.8": "2.34.0"
   "2.16.9": "2.35.0"
   "2.17.0": "2.36.0"
+  "2.17.1": "2.37.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Second pass on hmcollector to update module dependencies related to hms-certs.

The hms-certs update required changes to pass vault related override values to hms-certs.

Adopted app version 2.17.1 for CSM 1.7.0 (helm chart 2.37.0)

### Issues and Related PRs

* Resolves [CASMHMS-6409](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6409)

### Testing

Updated mug with new version.  Ensured no issues in log files.  Power cycled node to ensure state changes rippled back to SMD.

Tested on:

* `mug`

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable