### PR TITLE
CASMHMS-6482: Updated image and module dependencies to latest versions

### DIFF
--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,11 +5,13 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.17.2] - 2025-04-21
+## [2.17.2] - 2025-04-18
 
 ### Update
 
 - Updated image and module dependencies to latest versions
+- Removed several sections of code that's now redundant with the latest
+  hms-base module
 - Update version of Go to v1.24
 - Internal tracking ticket: CASMHMS-6482 and CASMHMS-6401
 

--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,6 +5,14 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.2] - 2025-04-21
+
+### Update
+
+- Updated image and module dependencies to latest versions
+- Update version of Go to v1.24
+- Internal tracking ticket: CASMHMS-6482 and CASMHMS-6401
+
 ## [2.17.1] - 2025-03-11
 
 ### Security

--- a/charts/v2.17/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.17.1
+version: 2.17.2
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,9 +8,9 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.37.0"  # update pprof image version below as well
+appVersion: "2.38.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hms-hmcollector-pprof
-      image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.37.0
+      image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.38.0
   artifacthub.io/license: "MIT"

--- a/charts/v2.17/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.37.0
+  appVersion: 2.38.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -40,6 +40,7 @@ chartVersionToApplicationVersion:
   "2.16.9": "2.35.0"
   "2.17.0": "2.36.0"
   "2.17.1": "2.37.0"
+  "2.17.2": "2.38.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the hms-base, hms-certs, and hms-go-http-lib modules.  Several sections of hmcollector code were removed and/or replaced due to the most recent changes to hms-base.

Additionally upgraded Go from v1.23 to v1.24.

Adopted app version 2.38.0 for CSM 1.7.0 (helm chart 2.17.2).

### Issues and Related PRs

* Resolves [CASMHMS-6482](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6482)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of hmcollector.  Watched log files to ensure nothing obvious was wrong.  There are no CT tests to run.

Watched hmcollector logs to ensure no deviations from running without these changes.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable