### PR TITLE
CASMHMS-6257: Fixed lost subscription bug when Paradise BMCs reboot

### DIFF
--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,7 +5,7 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.17.3] - 2025-05-21
+## [2.17.3] - 2025-05-28
 
 ### Fixed
 

--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,6 +5,13 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.3] - 2025-05-23
+
+### Fixed
+
+- Fixed lost subscription bug when BMCs reboot
+- Updated image and module dependencies
+
 ## [2.17.2] - 2025-04-18
 
 ### Update

--- a/changelog/v2.17.md
+++ b/changelog/v2.17.md
@@ -5,12 +5,13 @@ All notable changes to this project for v2.17.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.17.3] - 2025-05-23
+## [2.17.3] - 2025-05-21
 
 ### Fixed
 
-- Fixed lost subscription bug when BMCs reboot
+- Fixed lost subscription bug when Paradise BMCs reboot
 - Updated image and module dependencies
+- Internal tracking ticket: CASMHMS-6257
 
 ## [2.17.2] - 2025-04-18
 

--- a/charts/v2.17/cray-hms-hmcollector/Chart.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-hmcollector"
-version: 2.17.2
+version: 2.17.3
 description: "Kubernetes resources for cray-hms-hmcollector"
 home: "https://github.com/Cray-HPE/hms-hmcollector-charts"
 sources:
@@ -8,9 +8,9 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.38.0"  # update pprof image version below as well
+appVersion: "2.39.0"  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-hms-hmcollector-pprof
-      image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.38.0
+      image: artifactory.algol60.net/csm-docker/stable/hms-hmcollector-pprof:2.39.0
   artifacthub.io/license: "MIT"

--- a/charts/v2.17/cray-hms-hmcollector/values.yaml
+++ b/charts/v2.17/cray-hms-hmcollector/values.yaml
@@ -1,6 +1,6 @@
 ---
 global:
-  appVersion: 2.38.0
+  appVersion: 2.39.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-hmcollector

--- a/cray-hms-hmcollector.compatibility.yaml
+++ b/cray-hms-hmcollector.compatibility.yaml
@@ -41,6 +41,7 @@ chartVersionToApplicationVersion:
   "2.17.0": "2.36.0"
   "2.17.1": "2.37.0"
   "2.17.2": "2.38.0"
+  "2.17.3": "2.39.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Most of the changes in this PR were the addition of code comments and more verbose logging.  These were added to help aid my understanding of what hmcollector was doing in the area of BMC subscriptions and event reception.

The only functional code change was fixing a bug associated with subscriptions never being recreated after Paradise BMCs rebooted.  BMC reboots, for the most part, usually only occur as part of the BMC fw update process.

Hmcollector attempts to create two subscriptions for every component in the system that speaks redfish.  The first subscription uses an empty registry prefix group, while the second subscription uses a "CrayTelemetry" registry prefix group.  The later subscription is used for streaming telemetry, which is only supported on Cray hardware.  Despite this, hmcollector has always attempted to create streaming telemetry subscriptions for all components.  During the streaming telemetry attempt, the POST operation to the BMC fails if the BMC doesn't support it.

When Paradise support was added to hmcollector, code was added to rfSubscribe() to avoid creating the streaming telemetry subscription, because the hardware doesn't support it!  However, hmcollector assumes all component types attempt both subscriptions even if those component types don't support streaming telemetry.  When a Paradise BMC becomes unreachable (because it's rebooting) and then comes back after a period of time, isDupRFSubscription() will never indicate back to rfVerifySub() that it needs to mark the BMC as RFSUBSTATUS_ERROR so that the subscription is re-attempted.  This is due to the "CrayTelemtry" registry prefix being absent when isDupRFSubscription() executes.

The fix here is to remove the code that prevented the streaming telemetry subscription from being attempted on Paradise hardware.  Instead, treat Paradise hardware identically to all the other hardware that doesn't support streaming telemetry.

One further note...  One can easily argue that the hmcollector code should be reworked so that the second streaming telemetry subscription is never attempted against hardware that doesn't support it.  On the surface this seems pretty simple.  However, I did try going down that path but the changes necessary kept spreading and going deeper.  At this point in the product life it doesn't seem worth it to incur the risk of such substantial changes when the current functionality has proven stable over many years, even though we're doing more work here than should really be necessary.

Adopted app version 2.39.0 for CSM 1.7.0 (helm chart 2.17.3).

### Issues and Related PRs

* Resolves [CASMHMS-6257](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6257)

### Testing

Tested on:

* `mug`

Test description:

With dev version of service in place, rebooted a Paradise BMC.  After BMC rebooted and hmcollector started communicating with it again, performed power cycle with PCS.  Verified power events were recieved by watching the hmcollector-poll logs.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable